### PR TITLE
Generate combined output for best ligands

### DIFF
--- a/covid_moonshot/analysis/structures.py
+++ b/covid_moonshot/analysis/structures.py
@@ -267,7 +267,7 @@ def slice_snapshot(
     get_stored_atom_indices_cached = (
         get_stored_atom_indices
         if cache_dir is None
-        else joblib.Memory(cachedir=cache_dir).cache(get_stored_atom_indices)
+        else joblib.Memory(cachedir=cache_dir, verbose=0).cache(get_stored_atom_indices)
     )
 
     stored_atom_indices = get_stored_atom_indices_cached(project_path, run)


### PR DESCRIPTION
- [x] Fix #16: Suppress joblib.Memory stdout output
- [ ] Generate `results.csv` with sorted best compounds
- [ ] Generate  `ligands.sdf` with sorted best compounds
- [ ] Generate `protein.pdb` corresponding to `ligands.sdf`