### PR TITLE
Compute free energy results by GEN

### DIFF
--- a/covid_moonshot/__init__.py
+++ b/covid_moonshot/__init__.py
@@ -1,1 +1,2 @@
+from .core import *
 from .lib import *

--- a/covid_moonshot/analysis/__init__.py
+++ b/covid_moonshot/analysis/__init__.py
@@ -18,8 +18,8 @@ def get_run_analysis(
         raise ValueError(f"Failed to analyze solvent: {e}")
 
     binding = Binding(
-        delta_f=solvent_phase.fe.delta_f - complex_phase.fe.delta_f,
-        ddelta_f=(complex_phase.fe.ddelta_f ** 2 + solvent_phase.fe.ddelta_f ** 2)
+        delta_f=solvent_phase.free_energy.delta_f - complex_phase.free_energy.delta_f,
+        ddelta_f=(complex_phase.free_energy.ddelta_f ** 2 + solvent_phase.free_energy.ddelta_f ** 2)
         ** 0.5,
     )
 

--- a/covid_moonshot/analysis/__init__.py
+++ b/covid_moonshot/analysis/__init__.py
@@ -18,8 +18,9 @@ def get_run_analysis(
         raise ValueError(f"Failed to analyze solvent: {e}")
 
     binding = Binding(
-        delta_f=solvent_phase.delta_f - complex_phase.delta_f,
-        ddelta_f=(complex_phase.ddelta_f ** 2 + solvent_phase.ddelta_f ** 2) ** 0.5,
+        delta_f=solvent_phase.fe.delta_f - complex_phase.fe.delta_f,
+        ddelta_f=(complex_phase.fe.ddelta_f ** 2 + solvent_phase.fe.ddelta_f ** 2)
+        ** 0.5,
     )
 
     return RunAnalysis(

--- a/covid_moonshot/analysis/__init__.py
+++ b/covid_moonshot/analysis/__init__.py
@@ -1,4 +1,5 @@
 from typing import List
+import numpy as np
 from covid_moonshot.core import Binding, RunAnalysis, Work
 from .free_energy import get_phase_analysis
 
@@ -19,8 +20,10 @@ def get_run_analysis(
 
     binding = Binding(
         delta_f=solvent_phase.free_energy.delta_f - complex_phase.free_energy.delta_f,
-        ddelta_f=(complex_phase.free_energy.ddelta_f ** 2 + solvent_phase.free_energy.ddelta_f ** 2)
-        ** 0.5,
+        ddelta_f=np.sqrt(
+            complex_phase.free_energy.ddelta_f ** 2
+            + solvent_phase.free_energy.ddelta_f ** 2
+        ),
     )
 
     return RunAnalysis(

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -213,7 +213,7 @@ def get_phase_analysis(
 
     gens = [
         get_gen_analysis(
-            gen=gen.item(),
+            gen=int(gen),
             works=ws[ws["gen"] == gen],
             min_num_work_values=min_num_work_values,
             work_precision_decimals=work_precision_decimals,

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -211,15 +211,15 @@ def get_phase_analysis(
 
     ws = filter_work_values(ws_all)
 
-    gens = {
+    gens = [
         get_gen_analysis(
             gen=gen,
-            ws[ws["gen"] == gen],
+            works=ws[ws["gen"] == gen],
             min_num_work_values=min_num_work_values,
             work_precision_decimals=work_precision_decimals,
         )
         for gen in sorted(set(ws["gen"]))
-    }
+    ]
 
     free_energy = get_free_energy(ws, min_num_work_values=min_num_work_values)
 

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -129,6 +129,7 @@ def get_free_energy(
 
 
 def get_gen_analysis(
+    gen: int,
     works: np.ndarray,
     min_num_work_values: Optional[int],
     work_precision_decimals: Optional[int],
@@ -167,6 +168,7 @@ def get_gen_analysis(
     free_energy = get_free_energy(works, min_num_work_values=min_num_work_values)
 
     return GenAnalysis(
+        gen=gen,
         free_energy=free_energy,
         forward_works=maybe_round(works["forward"]).tolist(),
         reverse_works=maybe_round(works["reverse"]).tolist(),
@@ -210,7 +212,8 @@ def get_phase_analysis(
     ws = filter_work_values(ws_all)
 
     gens = {
-        gen: get_gen_analysis(
+        get_gen_analysis(
+            gen=gen,
             ws[ws["gen"] == gen],
             min_num_work_values=min_num_work_values,
             work_precision_decimals=work_precision_decimals,

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -14,6 +14,7 @@ def mask_outliers(a: np.ndarray, max_value: float, max_n_devs: float) -> np.ndar
     Parameters
     ----------
     a : array_like
+        Input array
     max_value : float
         Remove values with magnitudes greater than this
     max_n_devs : float
@@ -22,9 +23,11 @@ def mask_outliers(a: np.ndarray, max_value: float, max_n_devs: float) -> np.ndar
 
     Returns
     -------
-    ndarray of bool
-        Boolean array of same shape as `a`, with False elements
-        marking outliers in `a` and all other elements True.
+    out : ndarray of bool
+        Boolean array of same shape as the input array `a`, with
+        `False` elements marking outliers in `a` and all other
+        elements `True`.
+        ``out.shape == a.shape``
     """
     return (np.abs(a) < max_value) & (np.abs(a - np.mean(a)) < max_n_devs * np.std(a))
 
@@ -46,8 +49,9 @@ def filter_work_values(
 
     Returns
     -------
-    ndarray
-        Filtered works
+    out : ndarray
+        1-D array of filtered works.
+        ``out.shape == (works.size, 1)``
     """
 
     mask_work_outliers = functools.partial(
@@ -68,8 +72,8 @@ def get_bar_overlap(works: np.ndarray) -> float:
 
     Parameters
     ----------
-    works : ndarray
-        Array of records containing fields "forward" and "reverse"
+    works : (N,) ndarray
+        1-D array of records containing fields "forward" and "reverse"
 
     Returns
     -------
@@ -92,8 +96,9 @@ def get_free_energy(
     """
     Parameters
     ----------
-    works : ndarray
-        Array of records containing fields "forward" and "reverse"
+    works : (N,) ndarray
+        1-D array of records containing fields "forward" and "reverse"
+        representing forward and reverse works, respectively
     min_num_work_values : int or None, optional
         Minimum number of valid work values required for
         analysis. Raises ValueError if not satisfied.

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -83,9 +83,7 @@ def get_bar_overlap(works: np.ndarray) -> float:
 
 
 def get_free_energy(
-    works: List[Work],
-    min_num_work_values: Optional[int] = 10,
-    work_precision_decimals: Optional[int] = 3,
+    works: List[Work], min_num_work_values: Optional[int] = 10,
 ) -> Tuple[FreeEnergy, np.ndarray]:
 
     ws_all = np.array(
@@ -127,11 +125,7 @@ def get_gen_analysis(
             else works.round(work_precision_decimals)
         )
 
-    free_energy, ws = get_free_energy(
-        works,
-        min_num_work_values=min_num_work_values,
-        work_precision_decimals=work_precision_decimals,
-    )
+    free_energy, ws = get_free_energy(works, min_num_work_values=min_num_work_values)
 
     return GenAnalysis(
         free_energy=free_energy,
@@ -184,10 +178,6 @@ def get_phase_analysis(
         for gen, gen_works in sorted(works_by_gen.items())
     }
 
-    free_energy, _ = get_free_energy(
-        works,
-        min_num_work_values=min_num_work_values,
-        work_precision_decimals=work_precision_decimals,
-    )
+    free_energy, _ = get_free_energy(works, min_num_work_values=min_num_work_values)
 
     return PhaseAnalysis(free_energy=free_energy, gens=gens)

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -213,7 +213,7 @@ def get_phase_analysis(
 
     gens = [
         get_gen_analysis(
-            gen=gen.item,
+            gen=gen.item(),
             works=ws[ws["gen"] == gen],
             min_num_work_values=min_num_work_values,
             work_precision_decimals=work_precision_decimals,

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -149,9 +149,6 @@ def get_phase_analysis(
         `min_num_work_values`
     """
 
-    # phase-level result
-    fe = get_free_energy(works, min_num_work_values, work_precision_decimals)
-
     # gen-level results
     works_by_gen = defaultdict(list)
     for work in works:
@@ -159,11 +156,22 @@ def get_phase_analysis(
 
     gens = [
         GenAnalysis(
-            fe=get_free_energy(gen_works),
+            free_energy=get_free_energy(
+                gen_works,
+                min_num_work_values=min_num_work_values,
+                work_precision_decimals=work_precision_decimals,
+            ),
             forward_works=[w.forward_work for w in gen_works],
             reverse_works=[w.reverse_work for w in gen_works],
         )
         for _, gen_works in sorted(works_by_gen.items())
     ]
 
-    return PhaseAnalysis(fe=fe, gens=gens)
+    return PhaseAnalysis(
+        free_energy=get_free_energy(
+            works,
+            min_num_work_values=min_num_work_values,
+            work_precision_decimals=work_precision_decimals,
+        ),
+        gens=gens,
+    )

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -213,7 +213,7 @@ def get_phase_analysis(
 
     gens = [
         get_gen_analysis(
-            gen=gen,
+            gen=gen.item,
             works=ws[ws["gen"] == gen],
             min_num_work_values=min_num_work_values,
             work_precision_decimals=work_precision_decimals,

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import functools
 from typing import List, Optional, Tuple
 import numpy as np

--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -170,6 +170,6 @@ def get_phase_analysis(
         for gen in sorted(set(ws["gen"]))
     }
 
-    free_energy = get_free_energy(works, min_num_work_values=min_num_work_values)
+    free_energy = get_free_energy(ws, min_num_work_values=min_num_work_values)
 
     return PhaseAnalysis(free_energy=free_energy, gens=gens)

--- a/covid_moonshot/app.py
+++ b/covid_moonshot/app.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from typing import Optional
 import simplejson as json
 import logging

--- a/covid_moonshot/app.py
+++ b/covid_moonshot/app.py
@@ -25,32 +25,32 @@ def analyze_runs_cli(
     Parameters
     ----------
     run_details_json_file : str
-        json file containing run metadata. The file should contain a
-        json object with values deserializable to `RunDetails`
+        JSON file containing run metadata. The file should contain a
+        JSON object with values deserializable to `RunDetails`
     complex_project_path : str
-        path to the FAH project directory containing configuration for
+        Path to the FAH project directory containing configuration for
         simulations of the complex,
         e.g. '/home/server/server2/projects/13422'
     complex_project_data_path : str
-        path to the FAH project data directory containing output data
+        Path to the FAH project data directory containing output data
         from simulations of the complex,
         e.g. "/home/server/server2/data/SVR314342810/PROJ13422"
     solvent_project_data_path : str
-        path to the FAH project data directory containing output data
+        Path to the FAH project data directory containing output data
         from simulations of the solvent,
         e.g. "/home/server/server2/data/SVR314342810/PROJ13423"
     output : str
-        write json output to this path
+        Write json output to this path
     snapshot_output_path : str
-        path where snapshots will be written
+        Path where snapshots will be written
     max_binding_delta_f : float, optional
-        if given, skip storing snapshot if dimensionless binding free
+        If given, skip storing snapshot if dimensionless binding free
         energy estimate exceeds this value
     cache_dir : str, optional
-        if given, cache intermediate analysis results in local
+        If given, cache intermediate analysis results in local
         directory of this name
     num_procs : int, optional
-        number of parallel processes to run
+        Number of parallel processes to run
     """
 
     results = analyze_runs(

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -85,5 +85,31 @@ class RunDetails:
 @dataclass_json
 @dataclass
 class Run:
+    """
+    Results of free energy analysis for a single run.
+
+    Parameters
+    ----------
+    details : RunDetails
+        Compound details extracted from input JSON
+    analysis : RunAnalysis
+        Results of free energy analysis
+
+    Examples
+    --------
+    >>> import json
+    >>> from covid_moonshot import Run
+
+    >>> # Extract results for RUN0, complex phase
+    >>> run = results[0]
+    >>> phase = run.analysis.complex_phase
+
+    >>> # Extract all works (ignoring GENs)
+    >>> all_forward_works = [forward_work for gen in phase.gens for forward_work in gen.forward_works]
+    >>> all_reverse_works = [reverse_work for gen in phase.gens for reverse_work in gen.reverse_works]
+
+    >>> # Extract works for specific gen
+    >>> forward_works = phase.gens[0].forward_works
+    """
     details: RunDetails
     analysis: RunAnalysis

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import List
 from dataclasses_json import dataclass_json
 
 
@@ -33,6 +33,7 @@ class FreeEnergy:
 @dataclass_json
 @dataclass
 class GenAnalysis:
+    gen: int
     free_energy: FreeEnergy
     forward_works: List[float]
     reverse_works: List[float]
@@ -42,7 +43,7 @@ class GenAnalysis:
 @dataclass
 class PhaseAnalysis:
     free_energy: FreeEnergy
-    gens: Dict[int, GenAnalysis]
+    gens: List[GenAnalysis]
 
 
 @dataclass_json

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -33,7 +33,7 @@ class FreeEnergy:
 @dataclass_json
 @dataclass
 class GenAnalysis:
-    fe: FreeEnergy
+    free_energy: FreeEnergy
     forward_works: List[float]
     reverse_works: List[float]
 
@@ -41,7 +41,7 @@ class GenAnalysis:
 @dataclass_json
 @dataclass
 class PhaseAnalysis:
-    fe: FreeEnergy
+    free_energy: FreeEnergy
     gens: List[GenAnalysis]
 
 

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -23,13 +23,26 @@ class Work:
 
 @dataclass_json
 @dataclass
-class PhaseAnalysis:
+class FreeEnergy:
     delta_f: float
     ddelta_f: float
     bar_overlap: float
+    num_work_values: int
+
+
+@dataclass_json
+@dataclass
+class GenAnalysis:
+    fe: FreeEnergy
     forward_works: List[float]
     reverse_works: List[float]
-    num_work_values: int
+
+
+@dataclass_json
+@dataclass
+class PhaseAnalysis:
+    fe: FreeEnergy
+    gens: List[GenAnalysis]
 
 
 @dataclass_json

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 from dataclasses_json import dataclass_json
 
 
@@ -42,7 +42,7 @@ class GenAnalysis:
 @dataclass
 class PhaseAnalysis:
     free_energy: FreeEnergy
-    gens: List[GenAnalysis]
+    gens: Dict[int, GenAnalysis]
 
 
 @dataclass_json

--- a/covid_moonshot/lib.py
+++ b/covid_moonshot/lib.py
@@ -152,30 +152,30 @@ def analyze_runs(
     Parameters
     ----------
     run_details_json_file : str
-        json file containing run metadata. The file should contain a
-        json object with values deserializable to `RunDetails`
+        JSON file containing run metadata. The file should contain a
+        JSON object with values deserializable to `RunDetails`
     complex_project_path : str
-        path to the FAH project directory containing configuration for
+        Path to the FAH project directory containing configuration for
         simulations of the complex,
         e.g. '/home/server/server2/projects/13422'
     complex_project_data_path : str
-        path to the FAH project data directory containing output data
+        Path to the FAH project data directory containing output data
         from simulations of the complex,
         e.g. "/home/server/server2/data/SVR314342810/PROJ13422"
     solvent_project_data_path : str
-        path to the FAH project data directory containing output data
+        Path to the FAH project data directory containing output data
         from simulations of the solvent,
         e.g. "/home/server/server2/data/SVR314342810/PROJ13423"
     snapshot_output_path : str
-        path where snapshots will be written
+        Path where snapshots will be written
     max_binding_delta_f : float, optional
-        if given, skip storing snapshot if dimensionless binding free
+        If given, skip storing snapshot if dimensionless binding free
         energy estimate exceeds this value
     cache_dir : str, optional
-        if given, cache intermediate analysis results in local
+        If given, cache intermediate analysis results in local
         directory of this name
     num_procs : int, optional
-        number of parallel processes to run
+        Number of parallel processes to run
 
     Returns
     -------


### PR DESCRIPTION
Addresses #35.

This PR adds computation of free energies at the GEN level (in addition to the preexisting run/phase-level computation). It also modifies the analysis JSON schema to include the GEN-level results.

The modified schema of the `analysis` section for each run looks like:

``` json
{
  "complex_phase": {
    "free_energy": {
      "delta_f": 42.42,
      "ddelta_f": 4.24,
      "bar_overlap": 0.85,
      "num_work_values": 424
    },
    "gens": [
      {
        "gen": 1,
        "free_energy": {
          "delta_f": 24.24,
          "ddelta_f": 2.42,
          "bar_overlap": 0.77,
          "num_work_values": 42
        },
        "forward_works": [42.4, 40.34, 44.83, ...],
        "reverse_works": [40.55, 38.12, 37.2, ...]
      },
      ...
    ]
  }
  ...
}

```

#### Usage examples

```python
import json
from covid_moonshot import Run

with open("analysis.json", "r") as f:
    results = [Run.from_dict(r) for r in json.load(f)]

# Extract results for RUN0, complex phase
run = results[0]
phase = run.analysis.complex_phase

# Extract all works (ignoring GENs)
all_forward_works = [forward_work for gen in phase.gens for forward_work in gen.forward_works]
all_reverse_works = [reverse_work for gen in phase.gens for reverse_work in gen.reverse_works]

# Extract works for specific gen
forward_works = phase.gens[0].forward_works
```
