### PR TITLE
Add timestamp to JSON output and all plots

### DIFF
--- a/covid_moonshot/analysis/free_energy.py
+++ b/covid_moonshot/analysis/free_energy.py
@@ -134,7 +134,19 @@ def get_free_energy(
         )
 
     delta_f, ddelta_f = BAR(works["forward"], works["reverse"])
+
+    if not np.isfinite(delta_f) or not np.isfinite(ddelta_f):
+        raise ValueError(
+            f"BAR free energy computation returned invalid result: "
+            f"{delta_f} ± {ddelta_f}"
+        )
+
     bar_overlap = get_bar_overlap(works)
+
+    if not np.isfinite(bar_overlap):
+        raise ValueError(
+            f"BAR overlap computation returned invalid result: {bar_overlap}"
+        )
 
     return FreeEnergy(
         delta_f=delta_f,

--- a/covid_moonshot/app.py
+++ b/covid_moonshot/app.py
@@ -1,6 +1,5 @@
 import os
 from typing import Optional
-import simplejson as json
 import logging
 import fire
 from .lib import analyze_runs
@@ -54,7 +53,7 @@ def analyze_runs_cli(
         Number of parallel processes to run
     """
 
-    results = analyze_runs(
+    analysis = analyze_runs(
         run_details_json_file=run_details_json_file,
         complex_project_path=complex_project_path,
         complex_project_data_path=complex_project_data_path,
@@ -65,10 +64,8 @@ def analyze_runs_cli(
         num_procs=num_procs,
     )
 
-    # NOTE: ignore_nan=True encodes NaN as null, ensuring we produce
-    # valid json even if there are NaNs in the output
     with open(os.path.join(output_dir, "analysis.json"), "w") as output_file:
-        json.dump([r.to_dict() for r in results], output_file, ignore_nan=True)
+        output_file.write(analysis.to_json())
 
 
 def main():

--- a/covid_moonshot/core.py
+++ b/covid_moonshot/core.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import datetime as dt
 from typing import List, Optional
 from dataclasses_json import dataclass_json
 
@@ -111,5 +112,13 @@ class Run:
     >>> # Extract works for specific gen
     >>> forward_works = phase.gens[0].forward_works
     """
+
     details: RunDetails
     analysis: RunAnalysis
+
+
+@dataclass_json
+@dataclass
+class Analysis:
+    updated_at: dt.datetime
+    runs: List[Run]

--- a/covid_moonshot/reports/__init__.py
+++ b/covid_moonshot/reports/__init__.py
@@ -1,14 +1,14 @@
 import os
 from typing import List
-from ..core import Run
+from ..core import Analysis
 from .index import get_index_html
 from .molecules import save_molecule_images
 
 
-def save_reports(runs: List[Run], path: str) -> None:
+def save_reports(analysis: Analysis, path: str) -> None:
     save_molecule_images(
-        runs=[run.details for run in runs], path=os.path.join(path, "images")
+        runs=[run.details for run in analysis.runs], path=os.path.join(path, "images")
     )
-    html = get_index_html(runs)
+    html = get_index_html(analysis)
     with open(os.path.join(path, "index.html"), "w") as f:
         f.write(html)

--- a/covid_moonshot/reports/index.py
+++ b/covid_moonshot/reports/index.py
@@ -5,7 +5,7 @@ import os
 from typing import List, Optional
 from jinja2 import Environment
 from ..analysis.constants import KT_KCALMOL
-from ..core import Binding, Run
+from ..core import Analysis, Binding
 from . import templates
 
 
@@ -47,10 +47,12 @@ def format_estimate_stderr(est: Estimate) -> str:
     return f"{round(est.stderr, prec):.{prec}f}"
 
 
-def get_index_html(runs: List[Run]) -> str:
+def get_index_html(analysis: Analysis) -> str:
     template = pkg_resources.read_text(templates, "index.html")
     environment = Environment()
     environment.filters["binding_estimate_kcal"] = binding_estimate_kcal
     environment.filters["format_estimate_point"] = format_estimate_point
     environment.filters["format_estimate_stderr"] = format_estimate_stderr
-    return environment.from_string(template).render(sprint=SPRINT_NUMBER, runs=runs)
+    return environment.from_string(template).render(
+        sprint=SPRINT_NUMBER, analysis=analysis
+    )

--- a/covid_moonshot/reports/templates/index.html
+++ b/covid_moonshot/reports/templates/index.html
@@ -11,6 +11,10 @@ html * {
   font-family: 'Roboto', sans-serif;
 }
 
+span.updated {
+    font-style: italic;
+}
+
 table {
   border-collapse: collapse;
   width: 100%;
@@ -68,6 +72,7 @@ th {
 </head>
 <body>
   <h1>COVID Moonshot Sprint {{ sprint }} Analysis</h1>
+  <span class="updated">Updated {{ analysis.updated_at.isoformat() }}</span>
   <h2>Summary</h2>
   <h3>Free energy distribution</h3>
   <a href="plots/relative_fe_dist.pdf">
@@ -94,7 +99,7 @@ th {
       <th colspan=2>Work distributions</th>
       <th colspan=2>Convergence</th>
     </tr>
-    {% for run in (runs | sort(attribute="analysis.binding.delta_f"))[:20] %}
+    {% for run in (analysis.runs | sort(attribute="analysis.binding.delta_f"))[:20] %}
     <tr>
       <td class="rank">{{ loop.index }}</td>
       <td >RUN{{ run.details.run_id() }}</td>
@@ -138,7 +143,7 @@ th {
       <th>Work distributions</th>
       <th>Convergence</th>
     </tr>
-    {% for run in runs | sort(attribute="analysis.binding.delta_f") %}
+    {% for run in analysis.runs | sort(attribute="analysis.binding.delta_f") %}
     <tr>
       <td class="rank">{{ loop.index }}</td>
       <td >RUN{{ run.details.run_id() }}</td>

--- a/covid_moonshot/reports/templates/index.html
+++ b/covid_moonshot/reports/templates/index.html
@@ -12,6 +12,7 @@ html * {
 }
 
 span.updated {
+    color: gray;
     font-style: italic;
 }
 
@@ -72,7 +73,7 @@ th {
 </head>
 <body>
   <h1>COVID Moonshot Sprint {{ sprint }} Analysis</h1>
-  <span class="updated">Updated {{ analysis.updated_at.isoformat() }}</span>
+  <span class="updated">Last updated: {{ analysis.updated_at.isoformat() }}</span>
   <h2>Summary</h2>
   <h3>Free energy distribution</h3>
   <a href="plots/relative_fe_dist.pdf">


### PR DESCRIPTION
Closes #56.

- Adds "Last updated" text at the top of the webpage: [image](https://user-images.githubusercontent.com/319411/92020946-d1e49e00-ed0d-11ea-8794-ff2df3f51c61.png)
- Adds "Updated" text as watermark to all generated plots: [image](https://user-images.githubusercontent.com/319411/92021031-f5a7e400-ed0d-11ea-9907-44c4e8848a44.png)
- Adds `update_at` field to analysis.json schema


Note that this also introduces slight modification to the `analysis.json` schema. It now looks like

``` json
{
  "updated_at": 1599069729.400727,
  "runs": [...]
}
```
(where `runs` is the previous schema).

The type of `updated_at` is [`timestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp). To convert it to a Python `datetime`, you can use

``` python
import datetime
datetime.datetime.fromtimestamp(1599069729.400727)
```