### PR TITLE
Cap progress bar at 100%

### DIFF
--- a/covid_moonshot/reports/index.py
+++ b/covid_moonshot/reports/index.py
@@ -86,7 +86,7 @@ class Progress(NamedTuple):
     total: int
 
     def percent_complete(self) -> float:
-        return 100 * self.completed / self.total
+        return min(100.0, 100.0 * self.completed / self.total)
 
 
 def _get_progress(


### PR DESCRIPTION
Prevent progress bar on the sprint status report from going over 100%.